### PR TITLE
Fix sorting recently updated BIP pages

### DIFF
--- a/templates/bip-recently-modified-template.php
+++ b/templates/bip-recently-modified-template.php
@@ -4,6 +4,7 @@
 	'title_li' => '',
 	'post_type' => 'bip',
 	'sort_column' => 'post_modified',
+	'sort_order' => 'desc',
 	'number' => 10
 ] ) ?>
 </ul>


### PR DESCRIPTION
I have noticed that my page displayed the earliest (first) modified BIP pages instead of recently updated, so I added sorting desc.

Tested on WordPress 6.1.1 with installed plugin version 1.2.1.

Not sure if it's exception, on my page works after my fix, so please verify if it's happen on other sites.